### PR TITLE
Resolved issue #2

### DIFF
--- a/app/(components)/EditTicketForm.jsx
+++ b/app/(components)/EditTicketForm.jsx
@@ -222,14 +222,11 @@ const EditTicketForm = ({ ticket }) => {
           <option value="done">Done</option>
         </select>
         <div className="flex flex-row flex-wrap justify-between gap-2">
-          {/* <input
+          <input
             type="submit"
             className="btn max-w-xs"
             value={EDITMODE ? "Update Ticket" : "Create Ticket"}
-          /> */}
-          <button type="submit" className="btn max-w-xs">
-            {EDITMODE ? "Update Ticket" : "Create Ticket"}
-          </button>
+          />
 
           {EDITMODE ? <button className="btn max-w-xs bg-red-600 text-slate-50 hover:bg-red-700 hover:text-slate-100" onClick={deleteTicket}>Delete</button> : ""}
         </div>

--- a/app/(components)/EditTicketForm.jsx
+++ b/app/(components)/EditTicketForm.jsx
@@ -46,6 +46,7 @@ const EditTicketForm = ({ ticket }) => {
         },
         body: JSON.stringify({ formData }),
       });
+
       if (!res.ok) {
         throw new Error("Failed to update ticket");
       }
@@ -57,6 +58,7 @@ const EditTicketForm = ({ ticket }) => {
         },
         body: JSON.stringify({ formData })
       });
+
       if (!res.ok) {
         throw new Error("Failed to create ticket");
       }
@@ -75,8 +77,33 @@ const EditTicketForm = ({ ticket }) => {
     "MVP"
   ];
 
+  const deleteTicket = async (e) => {
+    e.preventDefault()
+    try {
+      const conf = confirm("Do you really want to delete the Ticket: " + formData.title)
+
+      if (conf) {
+        const res = await fetch(`/api/Tickets/${ticket._id}`, {
+          method: "DELETE",
+          headers: {
+            "Content-type": "application/json",
+          }
+        });
+
+        if (!res.ok) {
+          throw new Error("Failed to delete ticket");
+        }
+        router.refresh();
+        router.push("/");
+      }
+    } catch (error) {
+      console.log(error);
+
+    }
+  }
+
   return (
-    <div className=" flex justify-center">
+    <div className="flex justify-center">
       <form
         onSubmit={handleSubmit}
         method="post"
@@ -172,7 +199,7 @@ const EditTicketForm = ({ ticket }) => {
             min="0"
             max="100"
             onChange={handleChange}
-            className="w-full" 
+            className="w-full"
           />
           <div className="absolute top-0 left-0 right-0 flex justify-between px-2">
             <span className="text-xs">0%</span>
@@ -194,11 +221,18 @@ const EditTicketForm = ({ ticket }) => {
           <option value="started">Started</option>
           <option value="done">Done</option>
         </select>
-        <input
-          type="submit"
-          className="btn max-w-xs"
-          value={EDITMODE ? "Update Ticket" : "Create Ticket"}
-        />
+        <div className="flex flex-row flex-wrap justify-between gap-2">
+          {/* <input
+            type="submit"
+            className="btn max-w-xs"
+            value={EDITMODE ? "Update Ticket" : "Create Ticket"}
+          /> */}
+          <button type="submit" className="btn max-w-xs">
+            {EDITMODE ? "Update Ticket" : "Create Ticket"}
+          </button>
+
+          {EDITMODE ? <button className="btn max-w-xs bg-red-600 text-slate-50 hover:bg-red-700 hover:text-slate-100" onClick={deleteTicket}>Delete</button> : ""}
+        </div>
       </form>
     </div>
   );

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -16,18 +16,18 @@ const getTickets = async () => {
     return res.json();
   } catch (error) {
     console.log("Error loading tickets: ", error);
-    return { tickets: [] }; 
+    return { tickets: [] };
   }
 };
 
 const Dashboard = () => {
   const [tickets, setTickets] = useState([]);
-  const [viewBy, setViewBy] = useState("category"); 
+  const [viewBy, setViewBy] = useState("category");
 
   useEffect(() => {
     const fetchTickets = async () => {
       const data = await getTickets();
-      setTickets(data?.tickets || []); 
+      setTickets(data?.tickets || []);
     };
 
     fetchTickets();


### PR DESCRIPTION
### Related Issue  
Closes #2 

### Type of Change
- [x] New Feature  
- [ ] Bug Fix  
- [ ] Code Refactor  
- [ ] Documentation Update  
- [ ] Other (please specify): 

### Description of Change  
A delete button is added in the update ticket page to delete that ticket. Before deleting the ticket, it requires a confirmation to delete the ticket.

### Implementation Details  
I have added a button to delete the ticket which is visible only when the ticket is getting updated and not visible when creating a new ticket. When the **Delete** button is clicked, a confirmation box pops up. On confirming, a fetch request is sent to **`/api/Tickets/${ticket._id}`**. The ticket gets permanently deleted from the database and the user is returned to the homepage with router.push("/") where the deleted ticket no longer exists.

### Demo  

https://github.com/user-attachments/assets/4d876ee7-2d54-485a-bb24-e64a9f9087df

