### PR TITLE
Create automatic pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,20 @@
+### Related Issue  
+Closes #issue number  
+
+### Type of Change
+Put `x` inside the square bracket to specify what type of change your PR is:  
+- [ ] New Feature  
+- [ ] Bug Fix  
+- [ ] Code Refactor  
+- [ ] Documentation Update  
+- [ ] Other (please specify): 
+
+### Description of Change  
+Give a description of the change your PR is bringing.
+
+### Implementation Details  
+Give details about how you are implementing the change.
+
+### Demo  
+Provide screenshots or a video demonstrating the feature in action.  
+(Include attachments or links, if applicable.)


### PR DESCRIPTION
a feature for automatically fetching PR template when creating a new PR on github, as it is tedious to copy paste it every time for all contributors