### PR TITLE
resolved issue_83 - fixed spelling of "INFORMATION MANAGEMENT" GROUP in Nav

### DIFF
--- a/app/(components)/Nav.jsx
+++ b/app/(components)/Nav.jsx
@@ -31,7 +31,7 @@ const Nav = () => {
       <div>
         
         
-        <p className=" text-default-text">INFORMATION MANAGEMANT GROUP</p>
+        <p className=" text-default-text">INFORMATION MANAGEMENT GROUP</p>
       </div>
     </nav>
   );


### PR DESCRIPTION
### Related Issue  
Closes #83 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [ ] New Feature  
- [X] Bug Fix  
- [ ] Code Refactor  
- [ ] Documentation Update  
- [ ] Other (please specify): 

### Description of Change  
 The incorrect spelling "INFORMATION MANAGEMANT GROUP" changed to correct spelling  "INFORMATION MANAGEMENT GROUP" in Navbar.

### Implementation Details  
Changed the text "INFORMATION MANAGEMANT GROUP" in Nav.jsx to "INFORMATION MANAGEMENT GROUP"

### Demo  
![image](https://github.com/user-attachments/assets/5b4843ed-bebc-4c05-adb7-b9633085bd69)


